### PR TITLE
Fix mood update/delete queries

### DIFF
--- a/apps/backend/src/moods/moods.service.ts
+++ b/apps/backend/src/moods/moods.service.ts
@@ -43,12 +43,19 @@ export class MoodsService {
         });
     }
 
-    updateForUser(userId: bigint, id: string, dto: UpdateMoodDto) {
+    async updateForUser(userId: bigint, id: string, dto: UpdateMoodDto) {
         const { tagIds, ...data } = dto
         const connectTags = tagIds?.map(id => ({ id: BigInt(id) })) ?? [];
 
+        const existing = await this.prisma.mood.findFirst({
+            where: { id: BigInt(id), user_id: userId, deleted_at: null },
+        });
+        if (!existing) {
+            return null;
+        }
+
         return this.prisma.mood.update({
-            where: { id: BigInt(id), user_id: userId },
+            where: { id: BigInt(id) },
             data: {
                 ...data,
                 tags: {
@@ -61,9 +68,16 @@ export class MoodsService {
         });
     }
 
-    removeForUser(userId: bigint, id: string) {
+    async removeForUser(userId: bigint, id: string) {
+        const existing = await this.prisma.mood.findFirst({
+            where: { id: BigInt(id), user_id: userId, deleted_at: null },
+        });
+        if (!existing) {
+            return null;
+        }
+
         return this.prisma.mood.delete({
-            where: { id: BigInt(id), user_id: userId },
+            where: { id: BigInt(id) },
         });
     }
 }


### PR DESCRIPTION
## Summary
- validate mood belongs to the user before updating or removing it
- update/delete by id only once validation succeeds

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684696c9cc908331a8486140f26f0bf6