### PR TITLE
Fix invalid CRUD queries and add ownership checks

### DIFF
--- a/apps/backend/src/tags/tags.service.ts
+++ b/apps/backend/src/tags/tags.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import {PrismaService} from "../prisma/prisma.service";
 import {CreateTagDto} from "./dto/create-tag.dto";
 import {UpdateTagDto} from "./dto/update-tag.dto";
@@ -29,16 +29,30 @@ export class TagsService {
         });
     }
 
-    updateForUser(userId: bigint, id: string, dto: UpdateTagDto) {
-        return this.prisma.tag.updateMany({
-            where: { id: BigInt(id), user_id: userId },
+    async updateForUser(userId: bigint, id: string, dto: UpdateTagDto) {
+        const existing = await this.prisma.tag.findFirst({
+            where: { id: BigInt(id), user_id: userId, deleted_at: null },
+        });
+        if (!existing) {
+            throw new NotFoundException(`Tag with id ${id} not found`);
+        }
+
+        return this.prisma.tag.update({
+            where: { id: BigInt(id) },
             data: dto,
         });
     }
 
-    removeForUser(userId: bigint, id: string) {
-        return this.prisma.tag.deleteMany({
-            where: { id: BigInt(id), user_id: userId },
+    async removeForUser(userId: bigint, id: string) {
+        const existing = await this.prisma.tag.findFirst({
+            where: { id: BigInt(id), user_id: userId, deleted_at: null },
+        });
+        if (!existing) {
+            throw new NotFoundException(`Tag with id ${id} not found`);
+        }
+
+        return this.prisma.tag.delete({
+            where: { id: BigInt(id) },
         });
     }
 }


### PR DESCRIPTION
## Summary
- verify resources belong to current user before updating or deleting
- throw NotFound when resource doesn't exist
- rely on Prisma delete middleware for soft deletion

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: eslint config missing)*

------
https://chatgpt.com/codex/tasks/task_e_68469ec43710833198db41ae0d32a323